### PR TITLE
Fixed rosdep strip install bug

### DIFF
--- a/MotorDriver/.gitignore
+++ b/MotorDriver/.gitignore
@@ -6,3 +6,5 @@
 
 lib/protoc-21.5
 lib/protoc2
+
+!CATKIN_IGNORE


### PR DESCRIPTION
Fixed rosdep install bug issue and Closes #14 . Error was found to occur after downloading and unzipping the protoc source code during the `MotorDriver/setup_pc.sh` script. This meant that rosdep threw an error while searching inside that directory. It was expected that the `COLCON_IGNORE` file would stop rosdep from searching in the `MotorDriver/` folder but this was found to not be the case ([rosdep issue](https://github.com/ros-infrastructure/rosdep/issues/786?fbclid=IwAR0pn6JD8N0L40E7Yg7AOKTK6MMqrw2m76n-JMyJPqqY-ZPLs8RY21z6Psw)). Therefore the `.gitignore` file was updated to add a `CATKIN_IGNORE` file to the `MotorDriver/` folder.

The following rosdep command can now be used to install new dependencies starting from `~\colcon_ws`:
```
rosdep install --from-paths src --ignore-src --skip-keys=librealsense2 -r --rosdistro $ROS_DISTRO -y --include-eol-distros
```